### PR TITLE
feat: habilita google analytics

### DIFF
--- a/app/markups/common/head.ejs
+++ b/app/markups/common/head.ejs
@@ -8,6 +8,9 @@
   <!-- Meta data -->
   <b:include data='blog' name='all-head-content'/>
 
+  <!-- Google Analytics -->
+  <b:include data='blog' name='google-analytics'/>
+
   <!-- Meta data: twitter -->
   <b:if cond='data:view.featuredImage'>
     <meta property='twitter:card' content='summary_large_image'/>


### PR DESCRIPTION
La inclusion google-analytics Ahora incluye tanto UA (Universal analytics) como GA4, por lo cual la migración es automática para los usuarios de Blogger.